### PR TITLE
Fix release workflow: handle empty draft flag properly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,9 @@ jobs:
           Write-Host "[DRY RUN] Assets: $assets"
           Write-Host "[DRY RUN] Draft: $draft"
         } else {
-          $draftFlag = if ($draft) { "--draft" } else { "" }
-          & gh release create $tag --repo $repo --title $tag $draftFlag $assets
+          if ($draft) {
+            & gh release create $tag --repo $repo --title $tag --draft $assets
+          } else {
+            & gh release create $tag --repo $repo --title $tag $assets
+          }
         }


### PR DESCRIPTION
The issue was that PowerShell was passing an empty string as an argument to gh release create, causing 'no matches found for ' error. Now use conditional execution instead.